### PR TITLE
Update Moto to Version 2.2.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   noarch: python
-  skip: True  # [py<3.5]
+  skip: True  # [py<3.5 or s390x]
   entry_points:
     - moto_server = moto.server:main
   script: {{ PYTHON }} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
   number: 0
   noarch: python
+  # there seem to be missing dependencies for s390x
   skip: True  # [py<3.7 or s390x]
   entry_points:
     - moto_server = moto.server:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   noarch: python
-  skip: True  # [py<3.5 or s390x]
+  skip: True  # [py<3.7 or s390x]
   entry_points:
     - moto_server = moto.server:main
   script: {{ PYTHON }} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,19 +8,20 @@ source:
   - url: https://pypi.io/packages/source/m/moto/moto-{{ version }}.tar.gz
     sha256: f94502cc5c075742cdd58a8983c0565f129a43d43bba2b9b6f14a5ace96ee751
   - url: https://github.com/spulec/moto/archive/{{ version }}.tar.gz
-    sha256: f94502cc5c075742cdd58a8983c0565f129a43d43bba2b9b6f14a5ace96ee751
+    sha256: 50ee292c82d2782d3253045037fae3e42ac45358ceff3a7274624aab228ea10b
     folder: github
 
 build:
   number: 0
   noarch: python
+  skip: True  # [py<3.5]
   entry_points:
     - moto_server = moto.server:main
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
     - wheel
     - setuptools
@@ -120,6 +121,7 @@ test:
     - nose-exclude
     - pytest
     - pip
+    - python <3.10
     - freezegun
     - parameterized
     # needed for passing pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,8 @@ source:
 build:
   number: 0
   noarch: python
-  # there seem to be missing dependencies for s390x
-  skip: True  # [py<37]
+  # there seem to be missing docker-py >=2.5.1 and cfn-lint >=0.4.0 for s390x
+  skip: True  # [py<37 or s390x]
   entry_points:
     - moto_server = moto.server:main
   script: {{ PYTHON }} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.0" %}
+{% set version = "2.2.9" %}
 
 package:
   name: moto
@@ -6,9 +6,9 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/m/moto/moto-{{ version }}.tar.gz
-    sha256: ab4f094bf50885c7e593c9d0a27756eeb522c916d6f58c02437cb3654835f8dd
+    sha256: f94502cc5c075742cdd58a8983c0565f129a43d43bba2b9b6f14a5ace96ee751
   - url: https://github.com/spulec/moto/archive/{{ version }}.tar.gz
-    sha256: 9e5683dfa8887fce03facecec1c1a2f265f137107050868ce65918c0122c1ac3
+    sha256: f94502cc5c075742cdd58a8983c0565f129a43d43bba2b9b6f14a5ace96ee751
     folder: github
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   number: 0
   noarch: python
   # there seem to be missing dependencies for s390x
-  skip: True  # [py<3.7 or s390x]
+  skip: True  # [py<37]
   entry_points:
     - moto_server = moto.server:main
   script: {{ PYTHON }} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -120,6 +120,7 @@ test:
     - nose
     - nose-exclude
     - pytest
+    - pluggy <1.0.0
     - pip
     - python <3.10
     - freezegun


### PR DESCRIPTION
1. check the upstream
https://github.com/spulec/moto/tree/2.2.9

2. check the pinnings
https://github.com/spulec/moto/blob/2.2.9/tox.ini
https://github.com/spulec/moto/blob/2.2.9/setup.py
https://github.com/spulec/moto/blob/2.2.9/setup.cfg
https://github.com/spulec/moto/blob/2.2.9/requirements-dev.txt

3. check changelogs
https://github.com/spulec/moto/blob/2.2.9/CHANGELOG.md

support for `python 2.7` has been removed in version `2.2.0`
The rest of the changes are bug fixes or new features

mo4. additional research
https://github.com/conda-forge/moto-feedstock/issues

There are currently no open issues mentioned in conda forge at the time of the review

5. verify dev_url
dev_url: https://github.com/spulec/moto

6. verify doc_url
doc_url: http://docs.getmoto.org

7. verify that pip is in the test section
8. verify the test section
9. additional tests

In order to test the `moto` package version `2.2.9` the following command was used:
`conda build moto-feedstock --test` 
The test result was the following:
`All tests passed`

In addition the `celery` package was used to test the `moto` package.
The pinning for `moto` in the `celery` package was modified to use `2.2.9`
The following command was used for testing:
`conda build celery-feedstock --test`
The test result was the following:
`All tests passed`

Based on the research findings and on the test results we can conclude that it is safe to update `moto` to version `2.2.9`
