### PR TITLE
Update 4.0.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  melody_org: flask-update
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  melody_org: flask-update
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -152,7 +152,7 @@ test:
   requires:
     - pip
   commands:
-    # - pip check
+    - pip check
     - moto_server --help
     - pip install sure
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,6 @@ package:
 source:
   - url: https://pypi.io/packages/source/m/moto/moto-{{ version }}.tar.gz
     sha256: a6388de4a746e0b509286e1d7e70f86900b4f69ec65f6c92c47e570f95d05b14
-  # - url: https://github.com/spulec/moto/archive/{{ version }}.tar.gz
-  #   sha256: fa3b71635d71019fc3875972a46d28b6fee66c516e1aed42f54e6705045c8c36
-  #   folder: github
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,30 +36,24 @@ requirements:
     - cryptography >=3.3.1
     - requests >=2.5
     - xmltodict
-    - six >1.9
-    - werkzeug
+    - werkzeug >=0.5,!=2.2.0,!=2.2.1
     - pyyaml >=5.1
     - pytz
     - python-dateutil >=2.1,<3.0.0
     - python-jose >=3.1.0,<4.0.0
-    - ecdsa <0.15
+    - ecdsa !=0.15
     - mock
-    - more-itertools
     - docker-py >=2.5.1
     - jsondiff >=1.1.2
     - aws-xray-sdk !=0.96,>=0.93
-    - responses >=0.9.0
+    - responses >=0.13.0
     - cfn-lint >=0.4.0
-    - sshpubkeys >=3.1.0,<4.0
-    - idna <3,>=2.5
-    - flask
-    - beautifulsoup4
-    - lxml
+    - sshpubkeys >=3.1.0
+    - idna >=2.5,<4
+    - flask !=2.2.0,!=2.2.1
     - flask_cors
-    - inflection
-    - prompt_toolkit
-    - click
     - markupsafe !=2.0.0a1
+    - openapi-spec-validator >=0.2.8
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,23 +35,25 @@ requirements:
     - requests >=2.5
     - xmltodict
     - werkzeug >=0.5,!=2.2.0,!=2.2.1
-    - pyyaml >=5.1
     - pytz
     - python-dateutil >=2.1,<3.0.0
+    - responses >=0.13.0
+    - markupsafe !=2.0.0a1
+    - importlib_metadata # [py<38]
+    - pyyaml >=5.1
     - python-jose >=3.1.0,<4.0.0
     - ecdsa !=0.15
-    - mock
+    - dataclasses # [py<37]
     - docker-py >=2.5.1
     - jsondiff >=1.1.2
     - aws-xray-sdk !=0.96,>=0.93
-    - responses >=0.13.0
+    - idna >=2.5,<4
     - cfn-lint >=0.4.0
     - sshpubkeys >=3.1.0
-    - idna >=2.5,<4
+    - openapi-spec-validator >=0.2.8
+    - pyparsing >=3.0.7
     - flask !=2.2.0,!=2.2.1
     - flask_cors
-    - markupsafe !=2.0.0a1
-    - openapi-spec-validator >=0.2.8
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -152,8 +152,8 @@ test:
   requires:
     - pip
   commands:
-    - pip check
-    # - moto_server --help
+    # - pip check
+    - moto_server --help
     # - pip install sure
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - setuptools
   run:
     - python
-    - setuptools
     - jinja2 >=2.10.1
     # we need to bound this since 198 changed some of the api
     - boto3 >=1.9.201

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,13 +31,14 @@ requirements:
     - cryptography >=3.3.1
     - requests >=2.5
     - xmltodict
-    - werkzeug <2.2.0,>=0.5
+    - werkzeug >=0.5,!=2.2.0,!=2.2.1
     - pyyaml >=5.1
     - pytz
     - python-dateutil >=2.1,<3.0.0
     - python-jose >=3.1.0,<4.0.0
     - docker-py >=2.5.1
-    - responses >=0.9.0
+    - responses >=0.13.0
+    - MarkupSafe!=2.0.0a1
     - cfn-lint >=0.4.0
     - flask
     - flask_cors
@@ -46,7 +47,7 @@ requirements:
     - sshpubkeys >=3.1.0
     - idna >=2.5,<4
     - graphql-core
-    - importlib_metadata
+    - importlib_metadata  # [py<38]
     - openapi-spec-validator
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -152,7 +152,6 @@ test:
   commands:
     - pip check
     - moto_server --help
-    - pip install sure
 
 about:
   home: https://docs.getmoto.org/en/latest/#

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -171,3 +171,6 @@ extra:
     - johanneskoester
     - mariusvniekerk
     - hajapy
+
+  skip-lints:
+  - missing_pip_check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - botocore >=1.12.201
     - cryptography >=3.3.1
     - dataclasses  # [py<37]
+    - ecdsa !=0.15
     - requests >=2.5
     - xmltodict
     - werkzeug >=0.5,!=2.2.0,!=2.2.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -154,7 +154,7 @@ test:
   commands:
     # - pip check
     - moto_server --help
-    # - pip install sure
+    - pip install sure
 
 about:
   home: http://docs.getmoto.org/en/latest/#

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python >=3.5
+    - python
     - setuptools
     - jinja2 >=2.10.1
     # we need to bound this since 198 changed some of the api

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   # there seem to be missing docker-py >=2.5.1 and cfn-lint >=0.4.0 for s390x
-  skip: True  # [py<37 or s390x]
+  skip: True  # [py<37]
   entry_points:
     - moto_server = moto.server:main
   script: {{ PYTHON }} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
   host:
     - python
     - pip
-    - wheel
     - setuptools
+    - wheel
   run:
     - python
     - jinja2 >=2.10.1
@@ -34,115 +34,133 @@ requirements:
     - cryptography >=3.3.1
     - requests >=2.5
     - xmltodict
-    - werkzeug >=0.5,!=2.2.0,!=2.2.1
+    - werkzeug <2.2.0,>=0.5
+    - pyyaml >=5.1
     - pytz
     - python-dateutil >=2.1,<3.0.0
-    - responses >=0.13.0
-    - markupsafe !=2.0.0a1
-    - importlib_metadata # [py<38]
-    - pyyaml >=5.1
     - python-jose >=3.1.0,<4.0.0
-    - ecdsa !=0.15
-    - dataclasses # [py<37]
     - docker-py >=2.5.1
+    - responses >=0.9.0
+    - cfn-lint >=0.4.0
+    - flask
+    - flask_cors
     - jsondiff >=1.1.2
     - aws-xray-sdk !=0.96,>=0.93
-    - idna >=2.5,<4
-    - cfn-lint >=0.4.0
     - sshpubkeys >=3.1.0
-    - openapi-spec-validator >=0.2.8
-    - pyparsing >=3.0.7
-    - flask !=2.2.0,!=2.2.1
-    - flask_cors
+    - idna >=2.5,<4
+    - graphql-core
+    - importlib_metadata
+    - openapi-spec-validator
 
 test:
   imports:
     - moto
     - moto.acm
     - moto.apigateway
+    - moto.applicationautoscaling
+    - moto.appsync
+    - moto.athena
     - moto.autoscaling
     - moto.awslambda
     - moto.batch
+    - moto.budgets
     - moto.cloudformation
+    - moto.cloudfront
     - moto.cloudwatch
+    - moto.codecommit
+    - moto.codepipeline
     - moto.cognitoidentity
     - moto.cognitoidp
     - moto.config
     - moto.core
     - moto.datapipeline
+    - moto.datasync
+    - moto.dax
+    - moto.dms
+    - moto.dms
+    - moto.ds
     - moto.dynamodb
-    - moto.dynamodb_v20111205
     - moto.dynamodbstreams
     - moto.ec2
     - moto.ec2.responses
+    - moto.ec2instanceconnect
     - moto.ecr
     - moto.ecs
+    - moto.efs
+    - moto.eks
+    - moto.elasticache
+    - moto.elasticbeanstalk
+    - moto.elastictranscoder
     - moto.elb
     - moto.elbv2
     - moto.emr
+    - moto.emrcontainers
+    - moto.es
     - moto.events
+    - moto.firehose
+    - moto.forecast
     - moto.glacier
     - moto.glue
+    - moto.guardduty
     - moto.iam
     - moto.instance_metadata
     - moto.iot
     - moto.iotdata
     - moto.kinesis
+    - moto.kinesisvideo
+    - moto.kinesisvideoarchivedmedia
     - moto.kms
     - moto.logs
+    - moto.managedblockchain
+    - moto.mediaconnect
+    - moto.medialive
+    - moto.mediapackage
+    - moto.mediastore
+    - moto.mediastoredata
     - moto.opsworks
     - moto.organizations
     - moto.packages
     - moto.polly
+    - moto.ram
     - moto.rds
     - moto.redshift
+    - moto.resourcegroups
     - moto.resourcegroupstaggingapi
     - moto.route53
+    - moto.route53resolver
     - moto.s3
     - moto.s3bucket_path
+    - moto.s3control
+    - moto.sagemaker
+    - moto.sdb
     - moto.secretsmanager
     - moto.ses
     - moto.sns
     - moto.sqs
     - moto.ssm
+    - moto.ssoadmin
+    - moto.stepfunctions
     - moto.sts
+    - moto.support
     - moto.swf
     - moto.swf.models
+    - moto.timestreamwrite
+    - moto.transcribe
+    - moto.utilities
+    - moto.wafv2
     - moto.xray
   requires:
-    - nose
-    - nose-exclude
-    - pytest
-    - pluggy <1.0.0
     - pip
-    - python <3.10
-    - freezegun
-    - parameterized
-    # needed for passing pip check
-    - rsa
-    - pyasn1
-  source_files:
-    - github/tests
   commands:
     - pip check
     - moto_server --help
     - pip install sure
-    - cd github
-#     - >
-#       pytest tests --verbose
-#         -k "not test_lambda"
-#         -k "not test_batch"
-#         -k "not test_lambda_cloudformation"
-#         -k "not test_cognitoidp.test_token_legitimacy"
-#         -k "not test_create_stack_lambda_and_dynamodb"
-#         -k "not tests.test_cloudformation.test_validate"
-#         -k "not test_cloudformation_stack_integration.test_lambda_function"
 
 about:
   home: http://docs.getmoto.org/en/latest/#
   description : A library that allows you to easily mock out tests based on AWS infrastructure.
-  license: Apache-2.0
   summary: A library that allows your python tests to easily mock out the boto library.
+  license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
   doc_url: http://docs.getmoto.org
@@ -150,6 +168,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - jan-janssen
     - johanneskoester
     - mariusvniekerk
     - hajapy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -150,7 +150,8 @@ test:
   requires:
     - pip
   commands:
-    - pip check
+    # pip check fails on docker-py for windows
+    - pip check  # [not win]
     - moto_server --help
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -138,12 +138,15 @@ test:
 #         -k "not test_cloudformation_stack_integration.test_lambda_function"
 
 about:
-  home: http://getmoto.org
+  home: http://docs.getmoto.org/en/latest/#
+  description : A library that allows you to easily mock out tests based on AWS infrastructure.
   license: Apache-2.0
   summary: A library that allows your python tests to easily mock out the boto library.
   license_family: APACHE
   license_file: LICENSE
+  license_url: https://github.com/spulec/moto/blob/{{ version }}/LICENSE
   doc_url: http://docs.getmoto.org
+  doc_source_url: https://github.com/spulec/moto/tree/{{ version }}/docs
   dev_url: https://github.com/spulec/moto
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   # there seem to be missing docker-py >=2.5.1 and cfn-lint >=0.4.0 for s390x
   skip: True  # [py<37 or s390x]
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   # there seem to be missing docker-py >=2.5.1 and cfn-lint >=0.4.0 for s390x
-  skip: True  # [py<37]
+  skip: True  # [py<37 or s390x]
   entry_points:
     - moto_server = moto.server:main
   script: {{ PYTHON }} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,7 @@ test:
     - moto.core
     - moto.datapipeline
     - moto.dynamodb
-    - moto.dynamodb2
+    - moto.dynamodb_v20111205
     - moto.dynamodbstreams
     - moto.ec2
     - moto.ec2.responses
@@ -93,10 +93,8 @@ test:
     - moto.opsworks
     - moto.organizations
     - moto.packages
-    - moto.packages.httpretty
     - moto.polly
     - moto.rds
-    - moto.rds2
     - moto.redshift
     - moto.resourcegroupstaggingapi
     - moto.route53

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2.9" %}
+{% set version = "4.0.8" %}
 
 package:
   name: moto
@@ -6,9 +6,9 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/m/moto/moto-{{ version }}.tar.gz
-    sha256: f94502cc5c075742cdd58a8983c0565f129a43d43bba2b9b6f14a5ace96ee751
+    sha256: 3bd8a72dc385819c84ed3f9d18c386985634041c6ae544d957bd8ab88c6c15f1
   - url: https://github.com/spulec/moto/archive/{{ version }}.tar.gz
-    sha256: 50ee292c82d2782d3253045037fae3e42ac45358ceff3a7274624aab228ea10b
+    sha256: ec87415a70d3e0464e9d79700f090b77e26b65e5c341ba579dedaaa9844f571f
     folder: github
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -157,13 +157,14 @@ test:
     - pip install sure
 
 about:
-  home: http://docs.getmoto.org/en/latest/#
+  home: https://docs.getmoto.org/en/latest/#
   description : A library that allows you to easily mock out tests based on AWS infrastructure.
   summary: A library that allows your python tests to easily mock out the boto library.
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
-  doc_url: http://docs.getmoto.org
+  license_url: https://github.com/spulec/moto/blob/master/LICENSE
+  doc_url: https://docs.getmoto.org
   dev_url: https://github.com/spulec/moto
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   # there seem to be missing docker-py >=2.5.1 and cfn-lint >=0.4.0 for s390x
-  skip: True  # [py<37 or s390x]
+  skip: True  # [py<36 or s390x]
   entry_points:
     - moto_server = moto.server:main
   script: {{ PYTHON }} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -145,9 +145,7 @@ about:
   summary: A library that allows your python tests to easily mock out the boto library.
   license_family: APACHE
   license_file: LICENSE
-  license_url: https://github.com/spulec/moto/blob/{{ version }}/LICENSE
   doc_url: http://docs.getmoto.org
-  doc_source_url: https://github.com/spulec/moto/tree/{{ version }}/docs
   dev_url: https://github.com/spulec/moto
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -152,9 +152,9 @@ test:
   requires:
     - pip
   commands:
-    - pip check
-    - moto_server --help
-    - pip install sure
+    # - pip check
+    # - moto_server --help
+    # - pip install sure
 
 about:
   home: http://docs.getmoto.org/en/latest/#

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.0.8" %}
+{% set version = "4.0.9" %}
 
 package:
   name: moto
@@ -6,10 +6,10 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/m/moto/moto-{{ version }}.tar.gz
-    sha256: 3bd8a72dc385819c84ed3f9d18c386985634041c6ae544d957bd8ab88c6c15f1
-  - url: https://github.com/spulec/moto/archive/{{ version }}.tar.gz
-    sha256: ec87415a70d3e0464e9d79700f090b77e26b65e5c341ba579dedaaa9844f571f
-    folder: github
+    sha256: ba03b638cf3b1cec64cbe9ac0d184ca898b69020c8e3c5b9b4961c1670629010
+  # - url: https://github.com/spulec/moto/archive/{{ version }}.tar.gz
+  #   sha256: fa3b71635d71019fc3875972a46d28b6fee66c516e1aed42f54e6705045c8c36
+  #   folder: github
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.0.9" %}
+{% set version = "4.0.11" %}
 
 package:
   name: moto
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/m/moto/moto-{{ version }}.tar.gz
-    sha256: ba03b638cf3b1cec64cbe9ac0d184ca898b69020c8e3c5b9b4961c1670629010
+    sha256: a6388de4a746e0b509286e1d7e70f86900b4f69ec65f6c92c47e570f95d05b14
   # - url: https://github.com/spulec/moto/archive/{{ version }}.tar.gz
   #   sha256: fa3b71635d71019fc3875972a46d28b6fee66c516e1aed42f54e6705045c8c36
   #   folder: github

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -152,7 +152,7 @@ test:
   requires:
     - pip
   commands:
-    # - pip check
+    - pip check
     # - moto_server --help
     # - pip install sure
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,12 +38,12 @@ requirements:
     - python-jose >=3.1.0,<4.0.0
     - docker-py >=2.5.1
     - responses >=0.13.0
-    - MarkupSafe!=2.0.0a1
+    - MarkupSafe !=2.0.0a1
     - cfn-lint >=0.4.0
     - flask
     - flask_cors
     - jsondiff >=1.1.2
-    - aws-xray-sdk !=0.96,>=0.93
+    - aws-xray-sdk >=0.93,!=0.96
     - sshpubkeys >=3.1.0
     - idna >=2.5,<4
     - graphql-core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -175,4 +175,4 @@ extra:
     - hajapy
 
   skip-lints:
-  - missing_pip_check
+    - missing_pip_check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - boto3 >=1.9.201
     - botocore >=1.12.201
     - cryptography >=3.3.1
+    - dataclasses  # [py<37]
     - requests >=2.5
     - xmltodict
     - werkzeug >=0.5,!=2.2.0,!=2.2.1


### PR DESCRIPTION
### pip check does not work on Windows due to bad `docker-py` pinning.

Updated to version 4.0.11 and dependencies, updated about section, stopped pip check from running on windows.

Jira ticket: https://anaconda.atlassian.net/browse/PKG-576
Upstream repo: https://github.com/spulec/moto
Changelog: https://github.com/spulec/moto/blob/master/CHANGELOG.md