### PR TITLE
5.0.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ build:
   number: 0
   # there seem to be missing docker-py >=2.5.1 and cfn-lint >=0.4.0 for s390x
   # there is also and issue with 3.12 and graphql-core which results in a failed build
-  skip: True  # [py<37 or s390x or py>311]
+  skip: True  # [py<37 or s390x]
   entry_points:
     - moto_server = moto.server:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
@@ -25,7 +25,6 @@ requirements:
     - wheel
   run:
     - python
-    # we need to bound this since 198 changed some of the api
     - boto3 >=1.9.201
     - botocore >=1.14.0
     - cryptography >=3.3.1
@@ -35,8 +34,6 @@ requirements:
     - python-dateutil >=2.1,<3.0.0
     - responses >=0.15.0
     - jinja2 >=2.10.1
-    - python-jose >=3.1.0,<4.0.0
-    - ecdsa !=0.15
     - docker-py >=2.5.1
     - graphql-core
     - pyyaml >=5.1
@@ -49,7 +46,7 @@ requirements:
     - openapi-spec-validator >=0.5.0
     - pyparsing >=3.0.7
     - antlr4-python3-runtime
-    - joserfc
+    - joserfc >=0.9.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.0.3" %}
+{% set version = "5.0.5" %}
 
 package:
   name: moto
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/m/moto/moto-{{ version }}.tar.gz
-    sha256: 070ac2edf89ad7aee28534481ce68e2f344c8a6a8fefec5427eea0d599bfdbdb
+    sha256: 2eaca2df7758f6868df420bf0725cd0b93d98709606f1fb8b2343b5bdc822d91
 
 build:
   number: 0
@@ -48,6 +48,7 @@ requirements:
     - openapi-spec-validator >=0.5.0
     - pyparsing >=3.0.7
     - antlr4-python3-runtime
+    - joserfc
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ requirements:
     - antlr4-python3-runtime
     - pyparsing >=3.0.7
     - jsonpath-ng
-    - py-partiql-parser==0.5.4
+    - py-partiql-parser 0.5.4
     - multipart
     
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 build:
   number: 0
   # there seem to be missing docker-py >=2.5.1 and cfn-lint >=0.4.0 for s390x
-  # there is also and issue with 3.12 and graphql-core which results in a failed build
   skip: True  # [py<37 or s390x]
   entry_points:
     - moto_server = moto.server:main
@@ -44,10 +43,12 @@ requirements:
     - jsondiff >=1.1.2
     - aws-xray-sdk >=0.93,!=0.96
     - openapi-spec-validator >=0.5.0
-    - pyparsing >=3.0.7
-    - antlr4-python3-runtime
     - joserfc >=0.9.0
 
+  run_constrained:
+    - antlr4-python3-runtime
+    - pyparsing >=3.0.7
+    
 test:
   imports:
     - moto

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.1.3" %}
+{% set version = "5.0.3" %}
 
 package:
   name: moto
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/m/moto/moto-{{ version }}.tar.gz
-    sha256: c8200ccaa9440c2e9daa0bd5e0bd768a719db5a2c82ea8d782f0e3fa09a3c5e2
+    sha256: 070ac2edf89ad7aee28534481ce68e2f344c8a6a8fefec5427eea0d599bfdbdb
 
 build:
   number: 0
@@ -14,13 +14,13 @@ build:
   skip: True  # [py<37 or s390x]
   entry_points:
     - moto_server = moto.server:main
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=40.6.0
     - wheel
   run:
     - python
@@ -45,8 +45,9 @@ requirements:
     - flask_cors
     - jsondiff >=1.1.2
     - aws-xray-sdk >=0.93,!=0.96
-    - openapi-spec-validator >=0.2.8
+    - openapi-spec-validator >=0.5.0
     - pyparsing >=3.0.7
+    - antlr4-python3-runtime
 
 test:
   imports:
@@ -145,6 +146,7 @@ test:
     - moto.utilities
     - moto.wafv2
     - moto.xray
+    - openapi_spec_validator.validation
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,17 +38,17 @@ requirements:
     - graphql-core
     - pyyaml >=5.1
     - cfn-lint >=0.40.0
-    - sshpubkeys >=3.1.0
     - flask !=2.2.0,!=2.2.1
     - flask_cors
     - jsondiff >=1.1.2
     - aws-xray-sdk >=0.93,!=0.96
     - openapi-spec-validator >=0.5.0
     - joserfc >=0.9.0
-
-  run_constrained:
     - antlr4-python3-runtime
     - pyparsing >=3.0.7
+    - jsonpath-ng
+    - py-partiql-parser==0.5.4
+    - multipart
     
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   # there seem to be missing docker-py >=2.5.1 and cfn-lint >=0.4.0 for s390x
-  skip: True  # [py<37 or s390x]
+  skip: True  # [py<37 or s390x or py>311]
   entry_points:
     - moto_server = moto.server:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 0
   # there seem to be missing docker-py >=2.5.1 and cfn-lint >=0.4.0 for s390x
+  # there is also and issue with 3.12 and graphql-core which results in a failed build
   skip: True  # [py<37 or s390x or py>311]
   entry_points:
     - moto_server = moto.server:main
@@ -26,13 +27,13 @@ requirements:
     - python
     # we need to bound this since 198 changed some of the api
     - boto3 >=1.9.201
-    - botocore >=1.12.201
+    - botocore >=1.14.0
     - cryptography >=3.3.1
     - requests >=2.5
     - xmltodict
     - werkzeug >=0.5,!=2.2.0,!=2.2.1
     - python-dateutil >=2.1,<3.0.0
-    - responses >=0.13.0
+    - responses >=0.15.0
     - jinja2 >=2.10.1
     - python-jose >=3.1.0,<4.0.0
     - ecdsa !=0.15

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,10 @@ source:
 build:
   number: 0
   # there seem to be missing docker-py >=2.5.1 and cfn-lint >=0.4.0 for s390x
-  skip: True  # [py<37 or s390x]
+  skip: True  # [py<38 or s390x]
   entry_points:
     - moto_server = moto.server:main
+    - moto_proxy = moto.proxy:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -33,7 +34,7 @@ requirements:
     - python-dateutil >=2.1,<3.0.0
     - responses >=0.15.0
     - jinja2 >=2.10.1
-    - docker-py >=2.5.1
+    - docker-py >=3.0.0
     - graphql-core
     - pyyaml >=5.1
     - cfn-lint >=0.40.0
@@ -146,7 +147,6 @@ test:
     - moto.utilities
     - moto.wafv2
     - moto.xray
-    - openapi_spec_validator.validation
   requires:
     - pip
   commands:


### PR DESCRIPTION
moto 5.0.5

**Destination channel:** defaults

### Links

- [PKG-3628](https://anaconda.atlassian.net/browse/PKG-3628) 
- [Upstream repository](https://github.com/getmoto/moto)
- [Upstream changelog/diff](https://github.com/getmoto/moto/releases/tag/5.0.5)
- Relevant dependency PRs:
  - ...

### Explanation of changes:
- re-pins and limit python 3.12 building due to graphql-core


[PKG-3628]: https://anaconda.atlassian.net/browse/PKG-3628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ